### PR TITLE
Block payment for prompts that exceed the task limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,13 @@
 .env.development.local
 .env.test.local
 *.env
+*.mnemonic
+*.seed
+*.secret
+*.secret.*
+.envrc
 secrets/
+.secrets/
 *.key
 *.pem
 *.p12

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CeloScribe is a Celo-based MiniApp that will let users pay for AI access one req
 CeloScribe keeps the monorepo shape and MiniPay wallet patterns that Celo Composer emphasizes, but it is customized for the CeloScribe product flow.
 
 - `apps/web` keeps the explicit MiniPay connect flow, chain guards, and live CELO/cUSD balance summary.
+- The composer validates prompt length against the selected task limit before payment opens, so oversized requests are blocked locally instead of failing after an on-chain payment.
 - `packages/contracts` contains the payment contract workspace.
 - The project intentionally does not force MiniPay auto-connect so wallet consent stays explicit.
 - See [docs/COMPOSER.md](docs/COMPOSER.md) for the upstream Composer notes and mapping.

--- a/apps/web/e2e/main-flow.spec.ts
+++ b/apps/web/e2e/main-flow.spec.ts
@@ -138,6 +138,27 @@ test('submitting a prompt without wallet shows an error', async ({ page }) => {
   await expect(page.locator('.prompt-panel__error')).toHaveText('Connect your wallet to continue.');
 });
 
+test('blocks payment when the prompt exceeds the selected task limit', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: /short text, \$0\.01 cUSD/i }).click();
+
+  const prompt = page.getByLabel('Task prompt');
+  const payButton = page.getByRole('button', { name: 'Pay and generate' });
+
+  await prompt.fill('a'.repeat(501));
+
+  await expect(page.locator('.prompt-panel__error')).toHaveText(
+    'Prompt too long. Max 500 characters for TEXT_SHORT.'
+  );
+  await expect(payButton).toBeDisabled();
+
+  await prompt.fill('a'.repeat(500));
+
+  await expect(page.locator('.prompt-panel__error')).toHaveCount(0);
+  await expect(payButton).toBeEnabled();
+});
+
 test('payment modal shows the correct price for the selected task type', async ({ page }) => {
   await installMockWallet(page);
   await mockFornoRpc(page);

--- a/apps/web/src/app/api/task/generate/route.ts
+++ b/apps/web/src/app/api/task/generate/route.ts
@@ -4,8 +4,7 @@ import { type Address, type Hash } from 'viem';
 
 import { routeTask } from '@/lib/ai/router';
 import type { TaskType } from '@/lib/ai/taskTypes';
-import { TASK_LIMITS } from '@/lib/ai/taskTypes';
-import { isSupportedTaskType } from '@/lib/ai/taskValidation';
+import { getPromptLimitError, isSupportedTaskType } from '@/lib/ai/taskValidation';
 import {
   badRequest,
   methodNotAllowed,
@@ -43,10 +42,10 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
     return badRequest(`Invalid taskType: ${body.taskType}`);
   }
 
-  const maxInputChars = TASK_LIMITS[body.taskType].maxInputChars;
+  const promptLimitError = getPromptLimitError(body.taskType, prompt);
 
-  if (prompt.length > maxInputChars) {
-    return badRequest(`Prompt too long. Max ${maxInputChars} characters for ${body.taskType}.`);
+  if (promptLimitError) {
+    return badRequest(promptLimitError);
   }
 
   const rateLimit = checkRateLimit(body.userAddress);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,6 +12,7 @@ import { useTaskPayment } from '@/hooks/useTaskPayment';
 import type { TaskResult } from '@/lib/ai/taskTypes';
 import type { TaskType } from '@/lib/ai/taskTypes';
 import { TASK_LIMITS } from '@/lib/ai/taskTypes';
+import { getPromptLimitError } from '@/lib/ai/taskValidation';
 import { TASK_PRICE_DISPLAY } from '@/lib/payment/taskPrices';
 
 const TASK_TYPES: TaskType[] = ['TEXT_SHORT', 'TEXT_LONG', 'IMAGE', 'TRANSLATE'];
@@ -39,6 +40,13 @@ export default function Home() {
 
     return TASK_LIMITS[selectedTask].maxInputChars;
   }, [selectedTask]);
+
+  const promptValidationError = useMemo(
+    () => getPromptLimitError(selectedTask, prompt),
+    [prompt, selectedTask]
+  );
+
+  const canOpenPayment = Boolean(selectedTask && prompt.trim() && !promptValidationError);
 
   useEffect(() => {
     if (paymentState !== 'done' || !selectedTask || !txHash || !address) {
@@ -120,7 +128,7 @@ export default function Home() {
   }
 
   function handleOpenPayment() {
-    if (!selectedTask || !prompt.trim()) {
+    if (!selectedTask || !prompt.trim() || promptValidationError) {
       return;
     }
 
@@ -253,8 +261,8 @@ export default function Home() {
                 className="btn btn--primary"
                 type="button"
                 onClick={handleOpenPayment}
-                disabled={!selectedTask || !prompt.trim()}
-                aria-disabled={!selectedTask || !prompt.trim()}
+                disabled={!canOpenPayment}
+                aria-disabled={!canOpenPayment}
               >
                 Pay and generate
               </button>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -46,6 +46,9 @@ export default function Home() {
     [prompt, selectedTask]
   );
 
+  const promptErrorId = 'taskPromptError';
+  const promptError = promptValidationError ?? resultError;
+
   const canOpenPayment = Boolean(selectedTask && prompt.trim() && !promptValidationError);
 
   useEffect(() => {
@@ -246,13 +249,13 @@ export default function Home() {
               onChange={(event) => setPrompt(event.target.value)}
               placeholder="Describe what you want CeloScribe to generate..."
               disabled={!selectedTask}
-              aria-describedby="promptTitle"
-              aria-invalid={Boolean(resultError)}
+              aria-describedby={promptError ? `promptTitle ${promptErrorId}` : 'promptTitle'}
+              aria-invalid={Boolean(promptValidationError)}
             />
 
-            {resultError && (
-              <p className="prompt-panel__error" role="alert">
-                {resultError}
+            {promptError && (
+              <p id={promptErrorId} className="prompt-panel__error" role="alert">
+                {promptError}
               </p>
             )}
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -244,7 +244,7 @@ export default function Home() {
             </label>
             <textarea
               id="taskPrompt"
-              className="prompt-panel__field"
+              className={`prompt-panel__field ${promptValidationError ? 'prompt-panel__field--invalid' : ''}`}
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
               placeholder="Describe what you want CeloScribe to generate..."

--- a/apps/web/src/lib/ai/taskValidation.test.ts
+++ b/apps/web/src/lib/ai/taskValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isSupportedTaskType } from './taskValidation';
+import { getPromptLimitError, isSupportedTaskType } from './taskValidation';
 
 describe('isSupportedTaskType', () => {
   it('accepts the supported task names', () => {
@@ -14,5 +14,25 @@ describe('isSupportedTaskType', () => {
     expect(isSupportedTaskType('toString')).toBe(false);
     expect(isSupportedTaskType('constructor')).toBe(false);
     expect(isSupportedTaskType('NOT_A_TASK')).toBe(false);
+  });
+});
+
+describe('getPromptLimitError', () => {
+  it('returns no error when the prompt stays within the selected limit', () => {
+    expect(getPromptLimitError('TEXT_SHORT', 'a'.repeat(500))).toBeNull();
+  });
+
+  it('trims surrounding whitespace before checking the prompt length', () => {
+    expect(getPromptLimitError('TEXT_SHORT', `  ${'a'.repeat(500)}  `)).toBeNull();
+  });
+
+  it('returns the selected task limit when the prompt exceeds it', () => {
+    expect(getPromptLimitError('TEXT_SHORT', 'a'.repeat(501))).toBe(
+      'Prompt too long. Max 500 characters for TEXT_SHORT.'
+    );
+  });
+
+  it('returns no error when no task is selected', () => {
+    expect(getPromptLimitError(null, 'a'.repeat(501))).toBeNull();
   });
 });

--- a/apps/web/src/lib/ai/taskValidation.ts
+++ b/apps/web/src/lib/ai/taskValidation.ts
@@ -4,3 +4,26 @@ import { TASK_LIMITS } from './taskTypes';
 export function isSupportedTaskType(taskType: string | undefined): taskType is TaskType {
   return Boolean(taskType && Object.prototype.hasOwnProperty.call(TASK_LIMITS, taskType));
 }
+
+export function getPromptLimitError(
+  taskType: TaskType | null | undefined,
+  prompt: string
+): string | null {
+  if (!taskType) {
+    return null;
+  }
+
+  const trimmedPrompt = prompt.trim();
+
+  if (!trimmedPrompt) {
+    return null;
+  }
+
+  const maxInputChars = TASK_LIMITS[taskType].maxInputChars;
+
+  if (trimmedPrompt.length <= maxInputChars) {
+    return null;
+  }
+
+  return `Prompt too long. Max ${maxInputChars} characters for ${taskType}.`;
+}

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -273,6 +273,11 @@
   outline-offset: 2px;
 }
 
+.prompt-panel__field--invalid {
+  border-color: color-mix(in srgb, var(--color-error) 72%, var(--color-border));
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.18);
+}
+
 .prompt-panel__actions,
 .modal__actions,
 .result-panel__actions {


### PR DESCRIPTION
This keeps the payment flow closed until the prompt fits the selected task limit.

Changes:
- Shared the prompt-length check between the composer and the task generation route.
- Showed an inline error on the prompt field and disabled payment until the input is valid.
- Added unit and Playwright regression coverage.

Validation:
- pnpm --dir apps/web test
- pnpm --dir apps/web exec playwright test e2e/main-flow.spec.ts

Closes #6
