### PR TITLE
fix(web): require a target language for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ CeloScribe keeps the monorepo shape and MiniPay wallet patterns that Celo Compos
 
 - `apps/web` keeps the explicit MiniPay connect flow, chain guards, and live CELO/cUSD balance summary.
 - The composer validates prompt length against the selected task limit before payment opens, so oversized requests are blocked locally instead of failing after an on-chain payment.
+- Translate requests now require a target-language selection in the compose flow, and the confirmed language is carried through payment and `/api/task/generate` so the output matches the request the user approved.
 - `packages/contracts` contains the payment contract workspace.
 - The project intentionally does not force MiniPay auto-connect so wallet consent stays explicit.
 - See [docs/COMPOSER.md](docs/COMPOSER.md) for the upstream Composer notes and mapping.

--- a/apps/web/e2e/main-flow.spec.ts
+++ b/apps/web/e2e/main-flow.spec.ts
@@ -209,7 +209,7 @@ test('translate flow requires a target language and shows it end to end', async 
   const payButton = page.getByRole('button', { name: 'Pay and generate' });
   await expect(payButton).toBeDisabled();
 
-  await page.getByLabel('Target language').selectOption('Yoruba');
+  await page.locator('#targetLanguage').selectOption('Yoruba');
   await expect(payButton).toBeEnabled();
 
   await payButton.click();

--- a/apps/web/e2e/main-flow.spec.ts
+++ b/apps/web/e2e/main-flow.spec.ts
@@ -89,6 +89,29 @@ async function mockTaskGeneration(page: Page) {
   });
 }
 
+async function mockTranslateGeneration(page: Page) {
+  await page.route('**/api/task/generate', async (route) => {
+    const payload = route.request().postDataJSON() as {
+      prompt?: string;
+      taskType?: string;
+      targetLanguage?: string;
+    };
+
+    expect(payload.taskType).toBe('TRANSLATE');
+    expect(payload.targetLanguage).toBe('Yoruba');
+
+    await route.fulfill({
+      contentType: 'application/json',
+      json: {
+        taskType: 'TRANSLATE' as const,
+        output: 'A translated response for the test prompt.',
+        provider: 'mock-provider',
+        processingMs: 42,
+      },
+    });
+  });
+}
+
 test('page loads and shows task cards', async ({ page }) => {
   await page.goto('/');
 
@@ -171,6 +194,38 @@ test('payment modal shows the correct price for the selected task type', async (
 
   await expect(page.getByRole('dialog', { name: 'Payment confirmation' })).toBeVisible();
   await expect(page.locator('.modal__amount')).toHaveText(/\$0\.08\s+cUSD/);
+});
+
+test('translate flow requires a target language and shows it end to end', async ({ page }) => {
+  await installMockWallet(page);
+  await mockFornoRpc(page);
+  await mockTranslateGeneration(page);
+  await page.goto('/');
+
+  await expect(page.locator('.wallet-banner__badge')).toHaveText('MiniPay');
+  await page.getByRole('button', { name: /translate, \$0\.02 cUSD/i }).click();
+  await page.getByLabel('Task prompt').fill('Translate this phrase for me.');
+
+  const payButton = page.getByRole('button', { name: 'Pay and generate' });
+  await expect(payButton).toBeDisabled();
+
+  await page.getByLabel('Target language').selectOption('Yoruba');
+  await expect(payButton).toBeEnabled();
+
+  await payButton.click();
+  await expect(page.getByRole('dialog', { name: 'Payment confirmation' })).toContainText(
+    'Target language: Yoruba'
+  );
+
+  await page.getByRole('button', { name: /pay \$0\.02 cUSD/i }).click();
+
+  await expect(page.getByText('Translation output', { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText('Target language: Yoruba')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText('A translated response for the test prompt.')).toBeVisible({
+    timeout: 15_000,
+  });
 });
 
 test('health endpoint returns 200', async ({ page }) => {

--- a/apps/web/src/app/api/task/generate/route.test.ts
+++ b/apps/web/src/app/api/task/generate/route.test.ts
@@ -83,6 +83,51 @@ describe('POST /api/task/generate', () => {
     });
   });
 
+  it('routes translate requests with the selected target language', async () => {
+    mockState.verifyPaymentMock.mockResolvedValue({ valid: true });
+    mockState.routeTaskMock.mockResolvedValue({
+      output: 'resultado traducido',
+      processingMs: 12,
+      provider: 'deepseek-chat',
+      taskType: 'TRANSLATE',
+      tokensUsed: 19,
+    });
+
+    const request = new Request('http://localhost/api/task/generate', {
+      body: JSON.stringify({
+        prompt: 'Translate this sentence.',
+        taskType: 'TRANSLATE',
+        targetLanguage: '  Spanish  ',
+        txHash: TEST_TX_HASH,
+        userAddress: TEST_USER_ADDRESS,
+      }),
+      method: 'POST',
+    });
+
+    const response = await POST(request as never);
+    const payload = (await response.json()) as {
+      output: string;
+      provider: string;
+      taskType: string;
+      tokensUsed: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      output: 'resultado traducido',
+      processingMs: 12,
+      provider: 'deepseek-chat',
+      taskType: 'TRANSLATE',
+      tokensUsed: 19,
+    });
+    expect(mockState.verifyPaymentMock).toHaveBeenCalledWith(TEST_TX_HASH, TEST_USER_ADDRESS, 3);
+    expect(mockState.routeTaskMock).toHaveBeenCalledWith({
+      prompt: 'Translate this sentence.',
+      taskType: 'TRANSLATE',
+      targetLanguage: 'Spanish',
+    });
+  });
+
   it('rejects unknown task types before payment verification', async () => {
     const request = new Request('http://localhost/api/task/generate', {
       body: JSON.stringify({
@@ -193,6 +238,26 @@ describe('POST /api/task/generate', () => {
 
     expect(response.status).toBe(400);
     expect(payload.error).toBe('Prompt too long. Max 500 characters for TEXT_SHORT.');
+    expect(mockState.verifyPaymentMock).not.toHaveBeenCalled();
+    expect(mockState.routeTaskMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects translate requests without a target language before payment verification', async () => {
+    const request = new Request('http://localhost/api/task/generate', {
+      body: JSON.stringify({
+        prompt: 'Translate this sentence.',
+        taskType: 'TRANSLATE',
+        txHash: TEST_TX_HASH,
+        userAddress: TEST_USER_ADDRESS,
+      }),
+      method: 'POST',
+    });
+
+    const response = await POST(request as never);
+    const payload = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe('Required field: targetLanguage for TRANSLATE tasks.');
     expect(mockState.verifyPaymentMock).not.toHaveBeenCalled();
     expect(mockState.routeTaskMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/task/generate/route.ts
+++ b/apps/web/src/app/api/task/generate/route.ts
@@ -27,6 +27,8 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
   if (req.method !== 'POST') return methodNotAllowed(['POST']);
 
   const body = (await req.json()) as Partial<GenerateRequest>;
+  const targetLanguage =
+    typeof body.targetLanguage === 'string' ? body.targetLanguage.trim() : undefined;
 
   if (!body.txHash || !body.userAddress || !body.taskType || !body.prompt) {
     return badRequest('Required fields: txHash, userAddress, taskType, prompt');
@@ -48,6 +50,10 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
     return badRequest(promptLimitError);
   }
 
+  if (body.taskType === 'TRANSLATE' && !targetLanguage) {
+    return badRequest('Required field: targetLanguage for TRANSLATE tasks.');
+  }
+
   const rateLimit = checkRateLimit(body.userAddress);
 
   if (!rateLimit.allowed) {
@@ -64,7 +70,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
   const result = await routeTask({
     taskType: body.taskType,
     prompt,
-    ...(body.targetLanguage ? { targetLanguage: body.targetLanguage } : {}),
+    ...(targetLanguage ? { targetLanguage } : {}),
   });
 
   return NextResponse.json(result);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -333,7 +333,7 @@ export default function Home() {
               isLoading={isGenerating}
               taskType={selectedTask}
               prompt={prompt}
-              targetLanguage={pendingRequest?.targetLanguage}
+              {...(pendingTargetLanguage ? { targetLanguage: pendingTargetLanguage } : {})}
             />
           </div>
         </div>
@@ -345,11 +345,11 @@ export default function Home() {
         {isModalOpen && selectedTask && (
           <PaymentModal
             taskType={selectedTask}
-            targetLanguage={pendingRequest?.targetLanguage}
             paymentState={paymentState}
             error={paymentError}
             onConfirm={handleConfirmPayment}
             onCancel={handleCancelPayment}
+            {...(pendingTargetLanguage ? { targetLanguage: pendingTargetLanguage } : {})}
           />
         )}
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,10 @@ import type { TaskResult } from '@/lib/ai/taskTypes';
 import type { TaskType } from '@/lib/ai/taskTypes';
 import { TASK_LIMITS } from '@/lib/ai/taskTypes';
 import { getPromptLimitError } from '@/lib/ai/taskValidation';
+import {
+  TRANSLATION_TARGET_OPTIONS,
+  TRANSLATION_TARGET_PLACEHOLDER,
+} from '@/lib/ai/translationTargets';
 import { TASK_PRICE_DISPLAY } from '@/lib/payment/taskPrices';
 
 const TASK_TYPES: TaskType[] = ['TEXT_SHORT', 'TEXT_LONG', 'IMAGE', 'TRANSLATE'];
@@ -30,6 +34,7 @@ export default function Home() {
   const [activeTab, setActiveTab] = useState<'generate' | 'history'>('generate');
   const [selectedTask, setSelectedTask] = useState<TaskType | null>(null);
   const [prompt, setPrompt] = useState('');
+  const [targetLanguage, setTargetLanguage] = useState('');
   const [result, setResult] = useState<TaskResult | null>(null);
   const [resultError, setResultError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -47,9 +52,17 @@ export default function Home() {
   );
 
   const promptErrorId = 'taskPromptError';
+  const targetLanguageHintId = 'targetLanguageHint';
   const promptError = promptValidationError ?? resultError;
+  const isTranslateTask = selectedTask === 'TRANSLATE';
+  const selectedTargetLanguage = targetLanguage.trim();
 
-  const canOpenPayment = Boolean(selectedTask && prompt.trim() && !promptValidationError);
+  const canOpenPayment = Boolean(
+    selectedTask &&
+    prompt.trim() &&
+    !promptValidationError &&
+    (!isTranslateTask || selectedTargetLanguage)
+  );
 
   useEffect(() => {
     if (paymentState !== 'done' || !selectedTask || !txHash || !address) {
@@ -124,6 +137,9 @@ export default function Home() {
   function handleSelectTask(taskType: TaskType) {
     lastGeneratedTxHash.current = null;
     setSelectedTask(taskType);
+    if (taskType !== 'TRANSLATE') {
+      setTargetLanguage('');
+    }
     setResult(null);
     setResultError(null);
     setIsModalOpen(false);
@@ -253,6 +269,35 @@ export default function Home() {
               aria-invalid={Boolean(promptValidationError)}
             />
 
+            {isTranslateTask && (
+              <div className="prompt-panel__control-group">
+                <div>
+                  <label className="prompt-panel__label" htmlFor="targetLanguage">
+                    Target language
+                  </label>
+                  <p id={targetLanguageHintId} className="prompt-panel__hint">
+                    Pick the language for the translation before paying.
+                  </p>
+                </div>
+                <select
+                  id="targetLanguage"
+                  className={`prompt-panel__select ${selectedTargetLanguage ? '' : 'prompt-panel__select--placeholder'}`}
+                  value={targetLanguage}
+                  onChange={(event) => setTargetLanguage(event.target.value)}
+                  aria-describedby={targetLanguageHintId}
+                >
+                  <option value="" disabled>
+                    {TRANSLATION_TARGET_PLACEHOLDER}
+                  </option>
+                  {TRANSLATION_TARGET_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             {promptError && (
               <p id={promptErrorId} className="prompt-panel__error" role="alert">
                 {promptError}
@@ -278,6 +323,7 @@ export default function Home() {
               isLoading={isGenerating}
               taskType={selectedTask}
               prompt={prompt}
+              targetLanguage={isTranslateTask ? targetLanguage : undefined}
             />
           </div>
         </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,8 +9,7 @@ import { TransactionHistory } from '@/components/TransactionHistory';
 import { WalletBanner } from '@/components/WalletBanner';
 import { useMiniPay } from '@/hooks/useMiniPay';
 import { useTaskPayment } from '@/hooks/useTaskPayment';
-import type { TaskResult } from '@/lib/ai/taskTypes';
-import type { TaskType } from '@/lib/ai/taskTypes';
+import type { TaskRequest, TaskResult, TaskType } from '@/lib/ai/taskTypes';
 import { TASK_LIMITS } from '@/lib/ai/taskTypes';
 import { getPromptLimitError } from '@/lib/ai/taskValidation';
 import {
@@ -35,6 +34,7 @@ export default function Home() {
   const [selectedTask, setSelectedTask] = useState<TaskType | null>(null);
   const [prompt, setPrompt] = useState('');
   const [targetLanguage, setTargetLanguage] = useState('');
+  const [pendingRequest, setPendingRequest] = useState<TaskRequest | null>(null);
   const [result, setResult] = useState<TaskResult | null>(null);
   const [resultError, setResultError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -56,6 +56,9 @@ export default function Home() {
   const promptError = promptValidationError ?? resultError;
   const isTranslateTask = selectedTask === 'TRANSLATE';
   const selectedTargetLanguage = targetLanguage.trim();
+  const pendingPrompt = pendingRequest?.prompt;
+  const pendingTaskType = pendingRequest?.taskType;
+  const pendingTargetLanguage = pendingRequest?.targetLanguage;
 
   const canOpenPayment = Boolean(
     selectedTask &&
@@ -65,7 +68,7 @@ export default function Home() {
   );
 
   useEffect(() => {
-    if (paymentState !== 'done' || !selectedTask || !txHash || !address) {
+    if (paymentState !== 'done' || !pendingPrompt || !pendingTaskType || !txHash || !address) {
       return;
     }
 
@@ -89,8 +92,9 @@ export default function Home() {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            prompt,
-            taskType: selectedTask,
+            prompt: pendingPrompt,
+            taskType: pendingTaskType,
+            ...(pendingTargetLanguage ? { targetLanguage: pendingTargetLanguage } : {}),
             txHash,
             userAddress: address,
           }),
@@ -132,7 +136,7 @@ export default function Home() {
     return () => {
       isActive = false;
     };
-  }, [address, paymentState, prompt, selectedTask, txHash]);
+  }, [address, paymentState, pendingPrompt, pendingTargetLanguage, pendingTaskType, txHash]);
 
   function handleSelectTask(taskType: TaskType) {
     lastGeneratedTxHash.current = null;
@@ -140,6 +144,7 @@ export default function Home() {
     if (taskType !== 'TRANSLATE') {
       setTargetLanguage('');
     }
+    setPendingRequest(null);
     setResult(null);
     setResultError(null);
     setIsModalOpen(false);
@@ -162,17 +167,22 @@ export default function Home() {
     }
 
     lastGeneratedTxHash.current = null;
+    setPendingRequest({
+      prompt,
+      taskType: selectedTask,
+      ...(isTranslateTask ? { targetLanguage: selectedTargetLanguage } : {}),
+    });
     setResult(null);
     setResultError(null);
     setIsModalOpen(true);
   }
 
   async function handleConfirmPayment() {
-    if (!selectedTask) {
+    if (!pendingRequest) {
       return;
     }
 
-    await pay(selectedTask);
+    await pay(pendingRequest.taskType);
   }
 
   function handleCancelPayment() {
@@ -323,7 +333,7 @@ export default function Home() {
               isLoading={isGenerating}
               taskType={selectedTask}
               prompt={prompt}
-              targetLanguage={isTranslateTask ? targetLanguage : undefined}
+              targetLanguage={pendingRequest?.targetLanguage}
             />
           </div>
         </div>
@@ -335,6 +345,7 @@ export default function Home() {
         {isModalOpen && selectedTask && (
           <PaymentModal
             taskType={selectedTask}
+            targetLanguage={pendingRequest?.targetLanguage}
             paymentState={paymentState}
             error={paymentError}
             onConfirm={handleConfirmPayment}

--- a/apps/web/src/components/PaymentModal.tsx
+++ b/apps/web/src/components/PaymentModal.tsx
@@ -5,6 +5,7 @@ import { TASK_PRICE_DISPLAY } from '@/lib/payment/taskPrices';
 
 interface PaymentModalProps {
   taskType: TaskType;
+  targetLanguage?: string;
   paymentState: 'idle' | 'approving' | 'paying' | 'confirming' | 'done' | 'error';
   error: string | null;
   onConfirm: () => void;
@@ -22,6 +23,7 @@ const STATE_MESSAGES: Record<PaymentModalProps['paymentState'], string> = {
 
 export function PaymentModal({
   taskType,
+  targetLanguage,
   paymentState,
   error,
   onConfirm,
@@ -42,6 +44,9 @@ export function PaymentModal({
         <p className="modal__amount">
           {price} <span className="modal__currency">cUSD</span>
         </p>
+        {targetLanguage?.trim() && (
+          <p className="modal__detail">Target language: {targetLanguage.trim()}</p>
+        )}
         <p className="modal__status">{STATE_MESSAGES[paymentState]}</p>
         {error && (
           <p className="modal__error" role="alert">

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -30,7 +30,7 @@ const TASK_META: Record<
   TRANSLATE: {
     icon: '🌍',
     name: 'Translate',
-    description: 'Translate to Yoruba, Hausa, Igbo, French, and more',
+    description: 'Translate into a chosen target language',
     maxLen: '1500 chars',
   },
 };

--- a/apps/web/src/components/results/TranslateResult.tsx
+++ b/apps/web/src/components/results/TranslateResult.tsx
@@ -51,7 +51,10 @@ export function TranslateResult({ output, originalPrompt, targetLanguage }: Tran
 
   const sourceText = originalPrompt?.trim() ?? '';
   const translatedText = output?.trim() ?? '';
-  const languageLabel = targetLanguage?.trim() || 'Target language unavailable';
+  const languageLabel = targetLanguage?.trim();
+  const languageSummary = languageLabel
+    ? `Target language: ${languageLabel}`
+    : 'Target language unavailable';
 
   useEffect(() => {
     if (sourceCopyState !== 'copied') {
@@ -103,7 +106,7 @@ export function TranslateResult({ output, originalPrompt, targetLanguage }: Tran
       <div className="result-card__header result-card__header--stacked">
         <div>
           <p className="result-card__eyebrow">Translation output</p>
-          <p className="result-card__meta">{languageLabel}</p>
+          <p className="result-card__meta">{languageSummary}</p>
         </div>
       </div>
 

--- a/apps/web/src/lib/ai/translationTargets.ts
+++ b/apps/web/src/lib/ai/translationTargets.ts
@@ -1,0 +1,15 @@
+export interface TranslationTargetOption {
+  value: string;
+  label: string;
+}
+
+export const TRANSLATION_TARGET_OPTIONS: TranslationTargetOption[] = [
+  { value: 'English', label: 'English' },
+  { value: 'Yoruba', label: 'Yoruba' },
+  { value: 'Hausa', label: 'Hausa' },
+  { value: 'Igbo', label: 'Igbo' },
+  { value: 'French', label: 'French' },
+  { value: 'Spanish', label: 'Spanish' },
+];
+
+export const TRANSLATION_TARGET_PLACEHOLDER = 'Select a target language';

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -278,6 +278,40 @@
   box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.18);
 }
 
+.prompt-panel__control-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.prompt-panel__select {
+  width: 100%;
+  min-height: 2.85rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: rgba(10, 15, 30, 0.92);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--color-muted) 50%),
+    linear-gradient(135deg, var(--color-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 1.1rem) 52%,
+    calc(100% - 0.8rem) 52%;
+  background-repeat: no-repeat;
+  background-size: 0.35rem 0.35rem;
+  padding: 0.72rem 2.15rem 0.72rem 0.9rem;
+  color: var(--color-text);
+  font: inherit;
+  line-height: 1.2;
+}
+
+.prompt-panel__select--placeholder {
+  color: color-mix(in srgb, var(--color-muted) 78%, white);
+}
+
+.prompt-panel__select:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .prompt-panel__actions,
 .modal__actions,
 .result-panel__actions {
@@ -374,6 +408,14 @@
   margin-top: 0.65rem;
   color: var(--color-muted);
   line-height: 1.5;
+}
+
+.modal__detail {
+  margin: 0.45rem 0 0;
+  color: var(--color-accent);
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.4;
 }
 
 .modal__error,


### PR DESCRIPTION
This keeps Translate requests from reaching payment or generation without a target language.

What changed
- Added a compact target-language selector to the compose flow.
- Carried the selected language through the payment snapshot and `/api/task/generate`.
- Rejected TRANSLATE requests without a target language on the server.
- Updated the translation result card to label the chosen language clearly.
- Added API and Playwright coverage for the translation path.

Validation
- pnpm --dir apps/web lint
- pnpm --dir apps/web exec vitest run src/app/api/task/generate/route.test.ts
- pnpm --dir apps/web exec playwright test e2e/main-flow.spec.ts -g "translate flow requires a target language and shows it end to end"

Closes #8
