### PR TITLE
Clarify wallet readiness outside MiniPay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CeloScribe is a Celo-based MiniApp that will let users pay for AI access one req
 
 CeloScribe keeps the monorepo shape and MiniPay wallet patterns that Celo Composer emphasizes, but it is customized for the CeloScribe product flow.
 
-- `apps/web` keeps the explicit MiniPay connect flow, chain guards, and live CELO/cUSD balance summary.
+- `apps/web` keeps a MiniPay-first connect flow with a clear fallback for injected wallets and an explicit unsupported state when no provider is available.
 - The composer validates prompt length against the selected task limit before payment opens, so oversized requests are blocked locally instead of failing after an on-chain payment.
 - Translate requests now require a target-language selection in the compose flow, and the confirmed language is carried through payment and `/api/task/generate` so the output matches the request the user approved.
 - `packages/contracts` contains the payment contract workspace.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -25,8 +25,9 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 The app shell now mounts a client-side Web3 provider that combines Wagmi v2, Viem, and React Query for Celo mainnet and Alfajores support.
 
 - `src/lib/chains.ts` centralizes the Celo chain definitions and the cUSD contract address.
-- `src/lib/wagmi.ts` configures Wagmi with a MiniPay-aware injected connector that still works with other EIP-1193 wallets.
-- `src/hooks/useMiniPay.ts` exposes wallet state, MiniPay detection, and connect/disconnect actions.
+- `src/lib/wagmi.ts` configures Wagmi with a MiniPay-aware injected connector plus a generic injected fallback so the app can explain MiniPay-ready, injected-wallet, and unsupported-browser states.
+- `src/hooks/useMiniPay.ts` exposes wallet state, MiniPay detection, provider availability, and connect/disconnect actions.
+- `src/components/WalletBanner.tsx` surfaces the active wallet mode before the payment flow starts.
 - `src/components/WalletSummary.tsx` shows live CELO and cUSD balances so the wallet panel mirrors the Composer Minipay balance pattern.
 - `src/hooks/useCusdApproval.ts` and `src/hooks/useTaskPayment.ts` handle the client payment flow with receipt confirmation.
 - `src/lib/payment/taskPrices.ts` mirrors the on-chain task prices for UI display and payment checks.

--- a/apps/web/e2e/fixtures/mockWallet.ts
+++ b/apps/web/e2e/fixtures/mockWallet.ts
@@ -5,9 +5,21 @@ export const MOCK_CHAIN_ID = 42220;
 
 type Listener = (...args: unknown[]) => void;
 
+type WalletFixtureOptions = {
+  address?: string;
+  chainId?: number;
+  isMiniPay?: boolean;
+};
+
 export async function installMockWallet(page: Page) {
+  await installInjectedWallet(page, { isMiniPay: true });
+}
+
+export async function installInjectedWallet(page: Page, options: WalletFixtureOptions = {}) {
+  const { address = MOCK_ADDRESS, chainId = MOCK_CHAIN_ID, isMiniPay = false } = options;
+
   await page.addInitScript(
-    ({ address, chainId }) => {
+    ({ address, chainId, isMiniPay }) => {
       const listeners = new Map<string, Set<Listener>>();
       const accounts = [address];
 
@@ -22,7 +34,7 @@ export async function installMockWallet(page: Page) {
       }
 
       const ethereum = {
-        isMiniPay: true,
+        isMiniPay,
         chainId: `0x${chainId.toString(16)}`,
         selectedAddress: address,
         async request({ method }: { method: string }) {
@@ -88,8 +100,9 @@ export async function installMockWallet(page: Page) {
       };
     },
     {
-      address: MOCK_ADDRESS,
-      chainId: MOCK_CHAIN_ID,
+      address,
+      chainId,
+      isMiniPay,
     }
   );
 }

--- a/apps/web/e2e/main-flow.spec.ts
+++ b/apps/web/e2e/main-flow.spec.ts
@@ -1,6 +1,6 @@
 import { type Page, expect, test } from '@playwright/test';
 
-import { MOCK_ADDRESS, installMockWallet } from './fixtures/mockWallet';
+import { MOCK_ADDRESS, installInjectedWallet, installMockWallet } from './fixtures/mockWallet';
 
 const mockTaskResult = {
   taskType: 'TEXT_SHORT' as const,
@@ -122,10 +122,23 @@ test('page loads and shows task cards', async ({ page }) => {
   await expect(page.getByRole('button', { name: /translate, \$0\.02 cUSD/i })).toBeVisible();
 });
 
-test('wallet banner shows connect wallet when disconnected', async ({ page }) => {
+test('wallet banner explains the unsupported state when no wallet is injected', async ({
+  page,
+}) => {
   await page.goto('/');
 
-  await expect(page.getByRole('button', { name: 'Connect wallet' })).toBeVisible();
+  await expect(page.getByText('MiniPay required')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Open in MiniPay' })).toBeDisabled();
+});
+
+test('wallet banner shows a connected fallback wallet for a generic provider', async ({ page }) => {
+  await installInjectedWallet(page);
+  await mockFornoRpc(page);
+  await page.goto('/');
+
+  await expect(page.getByText('Connected through a browser wallet.')).toBeVisible();
+  await expect(page.getByText('0x1234...7890')).toBeVisible();
+  await expect(page.locator('.wallet-banner__badge')).toHaveText('Injected');
 });
 
 test('wallet banner shows the connected wallet address after mock injection', async ({ page }) => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -199,12 +199,12 @@ export default function Home() {
             Choose a task, pay in cUSD, and get the result in one flow.
           </h1>
           <p className="task-flow__subtitle">
-            Built for the MiniPay browser first: compact spacing, readable type, and no external
-            font runtime dependencies.
+            Built for MiniPay first, with a clear fallback for injected wallets and an explicit
+            unsupported state when no provider is available.
           </p>
         </section>
 
-        <div className="mt-4 flex items-center justify-between">
+        <div className="mt-4 w-full">
           <WalletBanner />
         </div>
 

--- a/apps/web/src/components/WalletBanner.tsx
+++ b/apps/web/src/components/WalletBanner.tsx
@@ -22,7 +22,7 @@ const walletBannerCopy = {
     eyebrow: 'MiniPay required',
     title: 'No injected wallet was found.',
     detail: 'Open CeloScribe in MiniPay or install a browser wallet before continuing.',
-    actionLabel: 'No wallet available',
+    actionLabel: 'Open in MiniPay',
   },
 } as const;
 
@@ -54,7 +54,11 @@ export function WalletBanner() {
 
   if (isConnected) {
     return (
-      <div className="wallet-banner wallet-banner--connected" aria-live="polite">
+      <div
+        className={`wallet-banner wallet-banner--connected wallet-banner--${walletConnectionState}`}
+        aria-live="polite"
+      >
+        <span className="wallet-banner__dot" aria-hidden="true" />
         <div className="wallet-banner__status-copy">
           <span className="wallet-banner__eyebrow">{bannerCopy.eyebrow}</span>
           <span className="wallet-banner__title" aria-label={`Connected wallet ${address ?? ''}`}>

--- a/apps/web/src/components/WalletBanner.tsx
+++ b/apps/web/src/components/WalletBanner.tsx
@@ -4,13 +4,38 @@ import { useSyncExternalStore } from 'react';
 
 import { useMiniPay } from '@/hooks/useMiniPay';
 
+const walletBannerCopy = {
+  miniPay: {
+    eyebrow: 'MiniPay ready',
+    title: 'This app is ready in MiniPay.',
+    detail: 'Use the MiniPay connector for the smoothest Celo payment flow.',
+    actionLabel: 'Connect MiniPay',
+  },
+  injected: {
+    eyebrow: 'Injected wallet detected',
+    title: 'A browser wallet is available.',
+    detail:
+      'CeloScribe can connect through the fallback wallet connector, but MiniPay is the primary experience.',
+    actionLabel: 'Connect wallet',
+  },
+  unsupported: {
+    eyebrow: 'MiniPay required',
+    title: 'No injected wallet was found.',
+    detail: 'Open CeloScribe in MiniPay or install a browser wallet before continuing.',
+    actionLabel: 'No wallet available',
+  },
+} as const;
+
 export function WalletBanner() {
-  const { isConnected, isMiniPay, address, connectWallet } = useMiniPay();
+  const { isConnected, isMiniPay, address, connectWallet, isConnecting, walletConnectionState } =
+    useMiniPay();
   const isMounted = useSyncExternalStore(
     () => () => {},
     () => true,
     () => false
   );
+
+  const bannerCopy = walletBannerCopy[walletConnectionState];
 
   if (!isMounted) {
     return (
@@ -30,24 +55,35 @@ export function WalletBanner() {
   if (isConnected) {
     return (
       <div className="wallet-banner wallet-banner--connected" aria-live="polite">
-        <span className="wallet-banner__dot" aria-hidden="true" />
-        <span aria-label={`Connected wallet ${address ?? ''}`}>
-          {address?.slice(0, 6)}...{address?.slice(-4)}
-        </span>
-        {isMiniPay && <span className="wallet-banner__badge">MiniPay</span>}
+        <div className="wallet-banner__status-copy">
+          <span className="wallet-banner__eyebrow">{bannerCopy.eyebrow}</span>
+          <span className="wallet-banner__title" aria-label={`Connected wallet ${address ?? ''}`}>
+            {address?.slice(0, 6)}...{address?.slice(-4)}
+          </span>
+          <span className="wallet-banner__detail">
+            {isMiniPay ? 'Connected through MiniPay.' : 'Connected through a browser wallet.'}
+          </span>
+        </div>
+        <span className="wallet-banner__badge">{isMiniPay ? 'MiniPay' : 'Injected'}</span>
       </div>
     );
   }
 
   return (
-    <div className="wallet-banner" aria-live="polite">
+    <div className={`wallet-banner wallet-banner--${walletConnectionState}`} aria-live="polite">
+      <div className="wallet-banner__status-copy">
+        <span className="wallet-banner__eyebrow">{bannerCopy.eyebrow}</span>
+        <span className="wallet-banner__title">{bannerCopy.title}</span>
+        <span className="wallet-banner__detail">{bannerCopy.detail}</span>
+      </div>
       <button
         onClick={connectWallet}
         className="btn btn--primary"
         type="button"
-        aria-label="Connect wallet"
+        aria-label={bannerCopy.actionLabel}
+        disabled={isConnecting || walletConnectionState === 'unsupported'}
       >
-        Connect Wallet
+        {isConnecting ? 'Connecting...' : bannerCopy.actionLabel}
       </button>
     </div>
   );

--- a/apps/web/src/hooks/useMiniPay.ts
+++ b/apps/web/src/hooks/useMiniPay.ts
@@ -3,7 +3,7 @@
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 
 import { celo } from '@/lib/chains';
-import { detectMiniPay } from '@/lib/minipay';
+import { detectMiniPay, getWalletConnectionState, hasInjectedWallet } from '@/lib/minipay';
 
 export function useMiniPay() {
   const { address, isConnected, chain } = useAccount();
@@ -11,6 +11,8 @@ export function useMiniPay() {
   const { disconnect } = useDisconnect();
 
   const isMiniPay = detectMiniPay();
+  const hasWalletProvider = hasInjectedWallet();
+  const walletConnectionState = getWalletConnectionState();
   const isOnCelo = chain?.id === celo.id;
 
   function connectWallet() {
@@ -29,6 +31,8 @@ export function useMiniPay() {
     isConnected,
     isConnecting,
     isMiniPay,
+    hasWalletProvider,
     isOnCelo,
+    walletConnectionState,
   };
 }

--- a/apps/web/src/hooks/useMiniPay.ts
+++ b/apps/web/src/hooks/useMiniPay.ts
@@ -16,7 +16,12 @@ export function useMiniPay() {
   const isOnCelo = chain?.id === celo.id;
 
   function connectWallet() {
-    const connector = connectors[0];
+    const connector =
+      walletConnectionState === 'miniPay'
+        ? (connectors[0] ?? connectors[1])
+        : walletConnectionState === 'injected'
+          ? (connectors[1] ?? connectors[0])
+          : undefined;
 
     if (!connector) return;
 

--- a/apps/web/src/lib/minipay.test.ts
+++ b/apps/web/src/lib/minipay.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { detectMiniPay, getWalletConnectionState, hasInjectedWallet } from './minipay';
+
+describe('wallet detection helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('detects MiniPay when the injected provider sets isMiniPay', () => {
+    vi.stubGlobal('window', {
+      ethereum: { isMiniPay: true },
+    });
+
+    expect(detectMiniPay()).toBe(true);
+    expect(hasInjectedWallet()).toBe(true);
+    expect(getWalletConnectionState()).toBe('miniPay');
+  });
+
+  it('detects a generic injected wallet without the MiniPay flag', () => {
+    vi.stubGlobal('window', {
+      ethereum: {},
+    });
+
+    expect(detectMiniPay()).toBe(false);
+    expect(hasInjectedWallet()).toBe(true);
+    expect(getWalletConnectionState()).toBe('injected');
+  });
+
+  it('marks browsers without an injected provider as unsupported', () => {
+    expect(detectMiniPay()).toBe(false);
+    expect(hasInjectedWallet()).toBe(false);
+    expect(getWalletConnectionState()).toBe('unsupported');
+  });
+});

--- a/apps/web/src/lib/minipay.ts
+++ b/apps/web/src/lib/minipay.ts
@@ -7,3 +7,23 @@ export function detectMiniPay(): boolean {
 
   return window.ethereum?.isMiniPay === true;
 }
+
+export type WalletConnectionState = 'miniPay' | 'injected' | 'unsupported';
+
+export function hasInjectedWallet(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  return Boolean(window.ethereum);
+}
+
+export function getWalletConnectionState(): WalletConnectionState {
+  if (detectMiniPay()) {
+    return 'miniPay';
+  }
+
+  if (hasInjectedWallet()) {
+    return 'injected';
+  }
+
+  return 'unsupported';
+}

--- a/apps/web/src/lib/wagmi.ts
+++ b/apps/web/src/lib/wagmi.ts
@@ -26,6 +26,7 @@ export const wagmiConfig = createConfig({
     injected({
       target: miniPayTarget,
     }),
+    injected(),
   ],
   transports: {
     [celo.id]: http(celoRpcUrl),

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -79,7 +79,11 @@
 }
 
 .task-tabs__button--active {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 88%, white), var(--color-accent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 88%, white),
+    var(--color-accent)
+  );
   color: #062a16;
 }
 
@@ -105,7 +109,11 @@
   padding: 0.95rem;
   color: var(--color-text);
   text-align: left;
-  transition: border-color 160ms ease, transform 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .task-card:hover:not(:disabled),
@@ -182,32 +190,78 @@
 
 .wallet-banner {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  min-height: 3rem;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 1.1rem;
+  background: rgba(17, 24, 39, 0.92);
+  padding: 0.95rem 1rem;
+  color: var(--color-text);
 }
 
 .wallet-banner--connected {
-  justify-content: flex-start;
   border: 1px solid rgba(53, 208, 127, 0.22);
-  border-radius: 999px;
-  background: rgba(17, 24, 39, 0.92);
-  padding: 0.6rem 0.85rem;
-  color: var(--color-text);
-  font-family: var(--font-mono);
-  font-size: 0.88rem;
+  background: linear-gradient(180deg, rgba(11, 46, 31, 0.94), rgba(17, 24, 39, 0.95));
+}
+
+.wallet-banner--miniPay {
+  border-color: rgba(53, 208, 127, 0.24);
+  background: linear-gradient(180deg, rgba(11, 46, 31, 0.94), rgba(17, 24, 39, 0.95));
+}
+
+.wallet-banner--injected {
+  border-color: rgba(96, 165, 250, 0.24);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(17, 24, 39, 0.95));
+}
+
+.wallet-banner--unsupported {
+  border-color: rgba(248, 113, 113, 0.24);
+  background: linear-gradient(180deg, rgba(54, 20, 30, 0.95), rgba(17, 24, 39, 0.95));
 }
 
 .wallet-banner__dot {
-  width: 0.6rem;
-  height: 0.6rem;
+  flex-shrink: 0;
+  width: 0.7rem;
+  height: 0.7rem;
   border-radius: 999px;
   background: var(--color-accent);
   box-shadow: 0 0 0 6px rgba(53, 208, 127, 0.12);
+  margin-top: 0.2rem;
+}
+
+.wallet-banner__status-copy {
+  display: grid;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.wallet-banner__eyebrow {
+  color: var(--color-accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.wallet-banner__title {
+  color: var(--color-text);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.wallet-banner__detail {
+  color: var(--color-muted);
+  font-size: 0.83rem;
+  line-height: 1.45;
 }
 
 .wallet-banner__badge {
+  align-self: center;
   border: 1px solid rgba(53, 208, 127, 0.24);
   border-radius: 999px;
   background: rgba(26, 107, 63, 0.28);
@@ -217,6 +271,37 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.wallet-banner .btn {
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.wallet-banner--connected .wallet-banner__badge {
+  border-color: rgba(53, 208, 127, 0.28);
+  background: rgba(26, 107, 63, 0.34);
+}
+
+.wallet-banner--connected.wallet-banner--injected .wallet-banner__badge {
+  border-color: rgba(96, 165, 250, 0.28);
+  background: rgba(30, 64, 175, 0.28);
+  color: #93c5fd;
+}
+
+@media (max-width: 640px) {
+  .wallet-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .wallet-banner .btn {
+    width: 100%;
+  }
+
+  .wallet-banner__badge {
+    align-self: flex-start;
+  }
 }
 
 .prompt-panel {
@@ -330,7 +415,12 @@
   font: inherit;
   font-weight: 700;
   line-height: 1;
-  transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease, color 160ms ease, opacity 160ms ease;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    opacity 160ms ease;
 }
 
 .btn:focus-visible {
@@ -344,7 +434,11 @@
 }
 
 .btn--primary {
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 88%, white), var(--color-accent));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 88%, white),
+    var(--color-accent)
+  );
   color: #062a16;
 }
 
@@ -606,7 +700,12 @@
 .transaction-history__line {
   display: block;
   border-radius: 999px;
-  background: linear-gradient(90deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.22), rgba(148, 163, 184, 0.12));
+  background: linear-gradient(
+    90deg,
+    rgba(148, 163, 184, 0.12),
+    rgba(148, 163, 184, 0.22),
+    rgba(148, 163, 184, 0.12)
+  );
   background-size: 200% 100%;
   animation: transaction-history-shimmer 1.4s ease-in-out infinite;
 }


### PR DESCRIPTION
This update makes the wallet connection state explicit when the app opens outside MiniPay.

- Shows whether the app is MiniPay-ready, connected to another injected wallet, or unsupported because no provider is present.
- Keeps MiniPay first while adding a generic injected fallback connector.
- Updates the banner, hero copy, and README notes so the flow reads consistently.
- Adds Playwright coverage for the unsupported state and the generic injected-wallet path.

Closes #9
